### PR TITLE
Add caution to README because this project does not work now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Ruboty::Talk
 Talk with you if given message didn't match any other handlers.
 
+# CAUTION: Ruboty::Talk does not work now. See [r7kamura/docomoru#3](https://github.com/r7kamura/docomoru/issues/3)
+
 ## Install
 ```ruby
 # Gemfile


### PR DESCRIPTION
This pull request adds a link to https://github.com/r7kamura/docomoru/issues/3 to README.
I think displaying the message is user-friendly. Because I spent time for investigating a problem with this gem. I guess I could reduce investigating time if it included this pull request.


Thank you for the great product. 